### PR TITLE
VCST-4487: Update module-ci workflow

### DIFF
--- a/.github/workflows/module-ci-common.yml
+++ b/.github/workflows/module-ci-common.yml
@@ -16,17 +16,6 @@ on:
       - samples/**
     branches:
       [master, dev]
-  pull_request:
-    branches:
-      [master, dev]
-    paths-ignore:
-      - 'docs/**'
-      - 'build/**'
-      - 'README.md'
-      - 'LICENSE'
-      - '**/argoDeploy.json'
-      - '**/cloudDeploy.json'
-      - samples/**
     
 jobs:
   ci:

--- a/.github/workflows/module-ci.yml
+++ b/.github/workflows/module-ci.yml
@@ -1,4 +1,4 @@
-# v3.800.24
+# based on v3.800.24
 name: Module CI vTest
 
 on:

--- a/.github/workflows/module-ci.yml
+++ b/.github/workflows/module-ci.yml
@@ -187,6 +187,7 @@ jobs:
           packageUrl: ${{ steps.blobRelease.outputs.packageUrl }}
 
       - name: Increment Patch Version
+        if: ${{ (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/master')  }}
         run: |
             vc-build IncrementPatch
             git add Directory.Build.props *module.manifest

--- a/.github/workflows/module-ci.yml
+++ b/.github/workflows/module-ci.yml
@@ -1,9 +1,9 @@
-# vTest CI
+# v3.800.24
 name: Module CI vTest
 
 on:
   schedule:
-    - cron: 0 0 * * 1-5
+  - cron: 0 0 * * 1-5
   workflow_dispatch:
   push:
     paths-ignore:
@@ -30,8 +30,8 @@ on:
 jobs:
   ci:
     if: ${{ github.actor != 'dependabot[bot]' &&
-           (github.event.pull_request.head.repo.full_name == github.repository ||
-           github.event.pull_request.head.repo.full_name == '') }}  # Check that PR not from forked repo and not from Dependabot
+        (github.event.pull_request.head.repo.full_name == github.repository ||
+        github.event.pull_request.head.repo.full_name == '') }}  # Check that PR not from forked repo and not from Dependabot
     runs-on: ubuntu-latest
     env:
       CLOUD_INSTANCE_BASE_URL: ${{secrets.CLOUD_INSTANCE_BASE_URL}}
@@ -47,17 +47,16 @@ jobs:
 
     outputs:
       artifactUrl: ${{ steps.artifactUrl.outputs.download_url }}
-      jira-keys: ${{ steps.jira_keys.outputs.jira-keys }}
       moduleId: ${{ steps.artifact_ver.outputs.moduleId }}
 
     steps:
-      - name: Set up Node 18
-        uses: actions/setup-node@v3
+      - name: Set up Node 20
+        uses: actions/setup-node@v4
         with:
-            node-version: '18'
+            node-version: '20'
 
       - name: Set up Java 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -67,12 +66,12 @@ jobs:
         run: |
           echo "RELEASE_STATUS=true" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Install VirtoCommerce.GlobalTool
-        run: dotnet tool install --global VirtoCommerce.GlobalTool --prerelease
+        uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
 
       - name: Install dotnet-sonarscanner
         run: dotnet tool install --global dotnet-sonarscanner
@@ -125,15 +124,30 @@ jobs:
         uses: VirtoCommerce/vc-github-actions/publish-blob-release@master
         with:
           blobSAS: ${{ secrets.BLOB_TOKEN }}
-          
+
       - name: Validate manifets
         run: vc-build ValidateManifest
+
+      - name: Sanitize branch name
+        if: ${{ github.event_name == 'pull_request' }}
+        id: sanitize_branch
+        env:
+          BRANCH_NAME: ${{ github.head_ref }}
+        run: |
+          # Keep only alphanumeric, hyphens, underscores, and forward slashes and limit length to 255 characters.
+          SANITIZED_BRANCH=$(printf '%s\n' "$BRANCH_NAME" | sed 's/[^-a-zA-Z0-9_/]//g' | cut -c1-255)
+          if [ -z "$SANITIZED_BRANCH" ]; then
+            echo "branch name is empty"
+            exit 1
+          else
+            echo "branchName=$SANITIZED_BRANCH" >> $GITHUB_OUTPUT
+          fi
 
       - name: Add Jira link
         if: ${{ github.event_name == 'pull_request' }}
         uses: VirtoCommerce/vc-github-actions/publish-jira-link@master
         with:
-          branchName: ${{ github.head_ref }}
+          branchName: ${{ steps.sanitize_branch.outputs.branchName }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -174,8 +188,8 @@ jobs:
 
       - name: Increment Patch Version
         run: |
-            vc-build IncrementPatch
-            git add Directory.Build.props *module.manifest
-            git commit -m "ci: Auto IncrementPatch"
-            git push
-
+          vc-build IncrementPatch
+          git add Directory.Build.props *module.manifest
+          git commit -m "ci: Auto IncrementPatch"
+          git push
+    

--- a/.github/workflows/module-ci.yml
+++ b/.github/workflows/module-ci.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           echo "RELEASE_STATUS=true" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -192,4 +192,3 @@ jobs:
             git add Directory.Build.props *module.manifest
             git commit -m "ci: Auto IncrementPatch"
             git push
-    

--- a/.github/workflows/module-ci.yml
+++ b/.github/workflows/module-ci.yml
@@ -3,7 +3,7 @@ name: Module CI vTest
 
 on:
   schedule:
-  - cron: 0 0 * * 1-5
+    - cron: 0 0 * * 1-5
   workflow_dispatch:
   push:
     paths-ignore:
@@ -30,8 +30,8 @@ on:
 jobs:
   ci:
     if: ${{ github.actor != 'dependabot[bot]' &&
-        (github.event.pull_request.head.repo.full_name == github.repository ||
-        github.event.pull_request.head.repo.full_name == '') }}  # Check that PR not from forked repo and not from Dependabot
+          (github.event.pull_request.head.repo.full_name == github.repository ||
+          github.event.pull_request.head.repo.full_name == '') }}  # Check that PR not from forked repo and not from Dependabot
     runs-on: ubuntu-latest
     env:
       CLOUD_INSTANCE_BASE_URL: ${{secrets.CLOUD_INSTANCE_BASE_URL}}
@@ -188,8 +188,8 @@ jobs:
 
       - name: Increment Patch Version
         run: |
-          vc-build IncrementPatch
-          git add Directory.Build.props *module.manifest
-          git commit -m "ci: Auto IncrementPatch"
-          git push
+            vc-build IncrementPatch
+            git add Directory.Build.props *module.manifest
+            git commit -m "ci: Auto IncrementPatch"
+            git push
     


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a new shared CI workflow and modernizes the existing module CI.
> 
> - Adds `module-ci-common.yml` with comprehensive build, test, packaging, release, Jira, E2E, and cloud deploy steps (supports `master/main/dev`, VC actions pinned to `VCST-571`, Node 20/Java 17, artifact/jira outputs, deployment matrix)
> - Updates `module-ci.yml`: moves to `ubuntu-latest`, Node 20 and actions `v4`, switches to `setup-vcbuild` action, adds branch name sanitization for Jira linking, adjusts conditions/outputs (removes `jira-keys`), and minor cleanup
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d90ef89fa17488289b4c3260b71ccd56cbd5404f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4487
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.CITest_3.800.498-pr-5-d90e.zip